### PR TITLE
add a cleaner for IPA data (pre-phonetised)

### DIFF
--- a/matcha/text/cleaners.py
+++ b/matcha/text/cleaners.py
@@ -105,6 +105,20 @@ def english_cleaners2(text):
     return phonemes
 
 
+def mmconv_ipa_simplify(text):
+    replacements = [
+        ("ɐ", "ə"),
+        ("ˈə", "ə"),
+        ("ʤ", "dʒ"),
+        ("ʧ", "tʃ"),
+        ("ᵻ", "ɪ"),
+    ]
+    for replacement in replacements:
+        text = text.replace(replacement[0], replacement[1])
+    phonemes = collapse_whitespace(text)
+    return phonemes
+
+
 # I am removing this due to incompatibility with several version of python
 # However, if you want to use it, you can uncomment it
 # and install piper-phonemize with the following command:

--- a/matcha/text/cleaners.py
+++ b/matcha/text/cleaners.py
@@ -105,7 +105,7 @@ def english_cleaners2(text):
     return phonemes
 
 
-def mmconv_ipa_simplify(text):
+def ipa_simplifier(text):
     replacements = [
         ("ɐ", "ə"),
         ("ˈə", "ə"),


### PR DESCRIPTION
Different versions of espeak represent things differently, it seems (also, there are some distinctions none of our speakers make, so normalising those away reduces perplexity a tiny amount).

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Fixes #\<issue_number>

## Before submitting

- [X] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [X] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [ ] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
