### PR TITLE
Fix unsafe squeeze method in mel dataset extraction

### DIFF
--- a/matcha/data/text_mel_datamodule.py
+++ b/matcha/data/text_mel_datamodule.py
@@ -209,7 +209,7 @@ class TextMelDataset(torch.utils.data.Dataset):
             self.f_min,
             self.f_max,
             center=False,
-        ).squeeze()
+        ).squeeze(dim=0)
         mel = normalize(mel, self.data_parameters["mel_mean"], self.data_parameters["mel_std"])
         return mel
 


### PR DESCRIPTION


## What does this PR do?

I have run through an error due to a small bug in the code causing that the short spectrograms (1 frame) get squeezed to (80,) instead of (80,1). This change fixes the bug.

Fixes #\<issue_number>

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun? 
Yes

Make sure you had fun coding 🙃
