### PR TITLE
Add learning scheduler option to matcha.yaml config

### DIFF
--- a/configs/model/matcha.yaml
+++ b/configs/model/matcha.yaml
@@ -14,3 +14,13 @@ data_statistics: ${data.data_statistics}
 out_size: null # Must be divisible by 4
 prior_loss: true
 use_precomputed_durations: ${data.load_durations}
+
+scheduler:
+  scheduler:
+    _target_: torch.optim.lr_scheduler.CosineAnnealingLR
+    _partial_: true
+    T_max: 200000
+    eta_min: 0.0
+  lightning_args:
+    interval: step
+    frequency: 1


### PR DESCRIPTION
## What does this PR do?

This PR adds support for learning rate schedulers (default: CosineAnnealingLR) via matcha.yaml config.

Previously, MatchaTTS didn't use any LR scheduler, which could limit training effectiveness.
The implementation follows the existing configuration pattern and integrates seamlessly with Hydra.
