### PR TITLE
Multi-language capabilities for MatchaTTS

### DIFF
--- a/configs/data/ljspeech.yaml
+++ b/configs/data/ljspeech.yaml
@@ -8,6 +8,7 @@ pin_memory: True
 cleaners: [english_cleaners2]
 add_blank: True
 n_spks: 1
+n_langs: 1
 n_fft: 1024
 n_feats: 80
 sample_rate: 22050

--- a/configs/data/vctk.yaml
+++ b/configs/data/vctk.yaml
@@ -9,6 +9,7 @@ valid_filelist_path: data/filelists/vctk_audio_sid_text_val_filelist.txt
 batch_size: 32
 add_blank: True
 n_spks: 109
+n_langs: 1
 data_statistics:  # Computed for vctk dataset
   mel_mean: -6.630575
   mel_std: 2.482914

--- a/configs/model/encoder/default.yaml
+++ b/configs/model/encoder/default.yaml
@@ -10,6 +10,8 @@ encoder_params:
   p_dropout: 0.1
   spk_emb_dim: 64
   n_spks: 1
+  lang_emb_dim: 64
+  n_langs: 1
   prenet: true
 
 duration_predictor_params:

--- a/configs/model/matcha.yaml
+++ b/configs/model/matcha.yaml
@@ -6,9 +6,11 @@ defaults:
   - optimizer: adam.yaml
 
 _target_: matcha.models.matcha_tts.MatchaTTS
-n_vocab: 178
+n_vocab: ${data.n_vocab}
 n_spks: ${data.n_spks}
+n_langs: ${data.n_langs}
 spk_emb_dim: 64
+lang_emb_dim: 64
 n_feats: 80
 data_statistics: ${data.data_statistics}
 out_size: null # Must be divisible by 4

--- a/matcha/cli.py
+++ b/matcha/cli.py
@@ -234,6 +234,7 @@ def cli():
     parser.add_argument("--text", type=str, default=None, help="Text to synthesize")
     parser.add_argument("--file", type=str, default=None, help="Text file to synthesize")
     parser.add_argument("--spk", type=int, default=None, help="Speaker ID")
+    parser.add_argument("--lang", type=int, default=None, help="Language ID")
     parser.add_argument(
         "--temperature",
         type=float,
@@ -283,10 +284,11 @@ def cli():
     texts = get_texts(args)
 
     spk = torch.tensor([args.spk], device=device, dtype=torch.long) if args.spk is not None else None
+    lang = torch.tensor([args.lang], device=device, dtype=torch.long) if args.lang is not None else None
     if len(texts) == 1 or not args.batched:
-        unbatched_synthesis(args, device, model, vocoder, denoiser, texts, spk)
+        unbatched_synthesis(args, device, model, vocoder, denoiser, texts, spk, lang)
     else:
-        batched_synthesis(args, device, model, vocoder, denoiser, texts, spk)
+        batched_synthesis(args, device, model, vocoder, denoiser, texts, spk, lang)
 
 
 class BatchedSynthesisDataset(torch.utils.data.Dataset):
@@ -313,7 +315,7 @@ def batched_collate_fn(batch):
     return {"x": x, "x_lengths": x_lengths}
 
 
-def batched_synthesis(args, device, model, vocoder, denoiser, texts, spk):
+def batched_synthesis(args, device, model, vocoder, denoiser, texts, spk, lang):
     total_rtf = []
     total_rtf_w = []
     processed_text = [process_text(i, text, "cpu") for i, text in enumerate(texts)]
@@ -333,6 +335,7 @@ def batched_synthesis(args, device, model, vocoder, denoiser, texts, spk):
             n_timesteps=args.steps,
             temperature=args.temperature,
             spks=spk.expand(b) if spk is not None else spk,
+            langs=lang.expand(b) if lang is not None else lang,
             length_scale=args.speaking_rate,
         )
 
@@ -356,7 +359,7 @@ def batched_synthesis(args, device, model, vocoder, denoiser, texts, spk):
     print("[🍵] Enjoy the freshly whisked 🍵 Matcha-TTS!")
 
 
-def unbatched_synthesis(args, device, model, vocoder, denoiser, texts, spk):
+def unbatched_synthesis(args, device, model, vocoder, denoiser, texts, spk, lang):
     total_rtf = []
     total_rtf_w = []
     for i, text in enumerate(texts):
@@ -375,6 +378,7 @@ def unbatched_synthesis(args, device, model, vocoder, denoiser, texts, spk):
             n_timesteps=args.steps,
             temperature=args.temperature,
             spks=spk,
+            langs=lang,
             length_scale=args.speaking_rate,
         )
         output["waveform"] = to_waveform(output["mel"], vocoder, denoiser, args.denoiser_strength)
@@ -403,6 +407,7 @@ def print_config(args):
     print(f"\t- Speaking rate: {args.speaking_rate}")
     print(f"\t- Number of ODE steps: {args.steps}")
     print(f"\t- Speaker: {args.spk}")
+    print(f"\t- Language: {args.lang}")
 
 
 def get_device(args):

--- a/matcha/data/text_mel_datamodule.py
+++ b/matcha/data/text_mel_datamodule.py
@@ -42,6 +42,8 @@ class TextMelDataModule(LightningDataModule):
         data_statistics,
         seed,
         load_durations,
+        n_vocab=None,
+        n_langs=None,
     ):
         super().__init__()
 
@@ -72,6 +74,7 @@ class TextMelDataModule(LightningDataModule):
             self.hparams.data_statistics,
             self.hparams.seed,
             self.hparams.load_durations,
+            n_langs=self.hparams.n_langs,
         )
         self.validset = TextMelDataset(  # pylint: disable=attribute-defined-outside-init
             self.hparams.valid_filelist_path,
@@ -88,6 +91,7 @@ class TextMelDataModule(LightningDataModule):
             self.hparams.data_statistics,
             self.hparams.seed,
             self.hparams.load_durations,
+            n_langs=self.hparams.n_langs,
         )
 
     def train_dataloader(self):
@@ -97,7 +101,7 @@ class TextMelDataModule(LightningDataModule):
             num_workers=self.hparams.num_workers,
             pin_memory=self.hparams.pin_memory,
             shuffle=True,
-            collate_fn=TextMelBatchCollate(self.hparams.n_spks),
+            collate_fn=TextMelBatchCollate(self.hparams.n_spks, self.hparams.n_langs),
         )
 
     def val_dataloader(self):
@@ -107,7 +111,7 @@ class TextMelDataModule(LightningDataModule):
             num_workers=self.hparams.num_workers,
             pin_memory=self.hparams.pin_memory,
             shuffle=False,
-            collate_fn=TextMelBatchCollate(self.hparams.n_spks),
+            collate_fn=TextMelBatchCollate(self.hparams.n_spks, self.hparams.n_langs),
         )
 
     def teardown(self, stage: Optional[str] = None):
@@ -140,6 +144,7 @@ class TextMelDataset(torch.utils.data.Dataset):
         data_parameters=None,
         seed=None,
         load_durations=False,
+        n_langs=1,
     ):
         self.filepaths_and_text = parse_filelist(filelist_path)
         self.n_spks = n_spks
@@ -153,6 +158,7 @@ class TextMelDataset(torch.utils.data.Dataset):
         self.f_min = f_min
         self.f_max = f_max
         self.load_durations = load_durations
+        self.n_langs = n_langs
 
         if data_parameters is not None:
             self.data_parameters = data_parameters
@@ -161,23 +167,36 @@ class TextMelDataset(torch.utils.data.Dataset):
         random.seed(seed)
         random.shuffle(self.filepaths_and_text)
 
+        if n_langs > 1:
+            all_langs = sorted(set([filepath_and_text[2] for filepath_and_text in self.filepaths_and_text]))
+            assert len(all_langs) == n_langs
+            self.lang_dict = {lang: i for i, lang in enumerate(all_langs)}
+            print('lang_dict:', self.lang_dict)
+
     def get_datapoint(self, filepath_and_text):
-        if self.n_spks > 1:
-            filepath, spk, text = (
-                filepath_and_text[0],
-                int(filepath_and_text[1]),
-                filepath_and_text[2],
-            )
-        else:
-            filepath, text = filepath_and_text[0], filepath_and_text[1]
-            spk = None
+        filepath = filepath_and_text[0]
+        spk = None
+        lang = None
+        text = filepath_and_text[-1]
+
+        # format: filepath|spk|lang|text
+        if self.n_spks > 1 and self.n_langs > 1:
+            spk = int(filepath_and_text[1])
+            lang = self.lang_dict[filepath_and_text[2]]
+        # format: filepath|spk|text
+        elif self.n_spks > 1:
+            spk = int(filepath_and_text[1])
+        # format: filepath|lang|text
+        elif self.n_langs > 1:
+            lang = self.lang_dict[filepath_and_text[1]]
 
         text, cleaned_text = self.get_text(text, add_blank=self.add_blank)
         mel = self.get_mel(filepath)
 
         durations = self.get_durations(filepath, text) if self.load_durations else None
 
-        return {"x": text, "y": mel, "spk": spk, "filepath": filepath, "x_text": cleaned_text, "durations": durations}
+        return {"x": text, "y": mel, "spk": spk, "filepath": filepath, "x_text": cleaned_text, "durations": durations,
+                "lang": lang}
 
     def get_durations(self, filepath, text):
         filepath = Path(filepath)
@@ -229,8 +248,9 @@ class TextMelDataset(torch.utils.data.Dataset):
 
 
 class TextMelBatchCollate:
-    def __init__(self, n_spks):
+    def __init__(self, n_spks, n_langs):
         self.n_spks = n_spks
+        self.n_langs = n_langs
 
     def __call__(self, batch):
         B = len(batch)
@@ -244,7 +264,7 @@ class TextMelBatchCollate:
         durations = torch.zeros((B, x_max_length), dtype=torch.long)
 
         y_lengths, x_lengths = [], []
-        spks = []
+        spks, langs = [], []
         filepaths, x_texts = [], []
         for i, item in enumerate(batch):
             y_, x_ = item["y"], item["x"]
@@ -253,6 +273,7 @@ class TextMelBatchCollate:
             y[i, :, : y_.shape[-1]] = y_
             x[i, : x_.shape[-1]] = x_
             spks.append(item["spk"])
+            langs.append(item["lang"])
             filepaths.append(item["filepath"])
             x_texts.append(item["x_text"])
             if item["durations"] is not None:
@@ -261,6 +282,7 @@ class TextMelBatchCollate:
         y_lengths = torch.tensor(y_lengths, dtype=torch.long)
         x_lengths = torch.tensor(x_lengths, dtype=torch.long)
         spks = torch.tensor(spks, dtype=torch.long) if self.n_spks > 1 else None
+        langs = torch.tensor(langs, dtype=torch.long) if self.n_langs > 1 else None
 
         return {
             "x": x,
@@ -268,6 +290,7 @@ class TextMelBatchCollate:
             "y": y,
             "y_lengths": y_lengths,
             "spks": spks,
+            "langs": langs,
             "filepaths": filepaths,
             "x_texts": x_texts,
             "durations": durations if not torch.eq(durations, 0).all() else None,

--- a/matcha/models/baselightningmodule.py
+++ b/matcha/models/baselightningmodule.py
@@ -57,6 +57,7 @@ class BaseLightningClass(LightningModule, ABC):
         x, x_lengths = batch["x"], batch["x_lengths"]
         y, y_lengths = batch["y"], batch["y_lengths"]
         spks = batch["spks"]
+        langs = batch["langs"]
 
         dur_loss, prior_loss, diff_loss, *_ = self(
             x=x,
@@ -64,6 +65,7 @@ class BaseLightningClass(LightningModule, ABC):
             y=y,
             y_lengths=y_lengths,
             spks=spks,
+            langs=langs,
             out_size=self.out_size,
             durations=batch["durations"],
         )
@@ -184,7 +186,8 @@ class BaseLightningClass(LightningModule, ABC):
                 x = one_batch["x"][i].unsqueeze(0).to(self.device)
                 x_lengths = one_batch["x_lengths"][i].unsqueeze(0).to(self.device)
                 spks = one_batch["spks"][i].unsqueeze(0).to(self.device) if one_batch["spks"] is not None else None
-                output = self.synthesise(x[:, :x_lengths], x_lengths, n_timesteps=10, spks=spks)
+                langs = one_batch["langs"][i].unsqueeze(0).to(self.device) if one_batch["langs"] is not None else None
+                output = self.synthesise(x[:, :x_lengths], x_lengths, n_timesteps=10, spks=spks, langs=langs)
                 y_enc, y_dec = output["encoder_outputs"], output["decoder_outputs"]
                 attn = output["attn"]
                 self.logger.experiment.add_image(

--- a/matcha/models/components/decoder.py
+++ b/matcha/models/components/decoder.py
@@ -360,7 +360,7 @@ class Decoder(nn.Module):
                 if m.bias is not None:
                     nn.init.constant_(m.bias, 0)
 
-    def forward(self, x, mask, mu, t, spks=None, cond=None):
+    def forward(self, x, mask, mu, t, spks=None, langs=None, cond=None):
         """Forward pass of the UNet1DConditional model.
 
         Args:
@@ -386,6 +386,10 @@ class Decoder(nn.Module):
         if spks is not None:
             spks = repeat(spks, "b c -> b c t", t=x.shape[-1])
             x = pack([x, spks], "b * t")[0]
+
+        if langs is not None:
+            langs = repeat(langs, "b c -> b c t", t=x.shape[-1])
+            x = pack([x, langs], "b * t")[0]
 
         hiddens = []
         masks = [mask]

--- a/matcha/models/components/flow_matching.py
+++ b/matcha/models/components/flow_matching.py
@@ -15,12 +15,16 @@ class BASECFM(torch.nn.Module, ABC):
         n_feats,
         cfm_params,
         n_spks=1,
+        n_langs=1,
         spk_emb_dim=128,
+        lang_emb_dim=128,
     ):
         super().__init__()
         self.n_feats = n_feats
         self.n_spks = n_spks
+        self.n_langs = n_langs
         self.spk_emb_dim = spk_emb_dim
+        self.lang_emb_dim = lang_emb_dim
         self.solver = cfm_params.solver
         if hasattr(cfm_params, "sigma_min"):
             self.sigma_min = cfm_params.sigma_min
@@ -30,7 +34,7 @@ class BASECFM(torch.nn.Module, ABC):
         self.estimator = None
 
     @torch.inference_mode()
-    def forward(self, mu, mask, n_timesteps, temperature=1.0, spks=None, cond=None):
+    def forward(self, mu, mask, n_timesteps, temperature=1.0, spks=None, langs=None, cond=None):
         """Forward diffusion
 
         Args:
@@ -50,9 +54,9 @@ class BASECFM(torch.nn.Module, ABC):
         """
         z = torch.randn_like(mu) * temperature
         t_span = torch.linspace(0, 1, n_timesteps + 1, device=mu.device)
-        return self.solve_euler(z, t_span=t_span, mu=mu, mask=mask, spks=spks, cond=cond)
+        return self.solve_euler(z, t_span=t_span, mu=mu, mask=mask, spks=spks, langs=langs, cond=cond)
 
-    def solve_euler(self, x, t_span, mu, mask, spks, cond):
+    def solve_euler(self, x, t_span, mu, mask, spks, langs, cond):
         """
         Fixed euler solver for ODEs.
         Args:
@@ -74,7 +78,7 @@ class BASECFM(torch.nn.Module, ABC):
         sol = []
 
         for step in range(1, len(t_span)):
-            dphi_dt = self.estimator(x, mask, mu, t, spks, cond)
+            dphi_dt = self.estimator(x, mask, mu, t, spks, langs, cond)
 
             x = x + dt * dphi_dt
             t = t + dt
@@ -84,7 +88,7 @@ class BASECFM(torch.nn.Module, ABC):
 
         return sol[-1]
 
-    def compute_loss(self, x1, mask, mu, spks=None, cond=None):
+    def compute_loss(self, x1, mask, mu, spks=None, langs=None, cond=None):
         """Computes diffusion loss
 
         Args:
@@ -112,21 +116,24 @@ class BASECFM(torch.nn.Module, ABC):
         y = (1 - (1 - self.sigma_min) * t) * z + t * x1
         u = x1 - (1 - self.sigma_min) * z
 
-        loss = F.mse_loss(self.estimator(y, mask, mu, t.squeeze(), spks), u, reduction="sum") / (
+        loss = F.mse_loss(self.estimator(y, mask, mu, t.squeeze(), spks, langs), u, reduction="sum") / (
             torch.sum(mask) * u.shape[1]
         )
         return loss, y
 
 
 class CFM(BASECFM):
-    def __init__(self, in_channels, out_channel, cfm_params, decoder_params, n_spks=1, spk_emb_dim=64):
+    def __init__(self, in_channels, out_channel, cfm_params, decoder_params, n_spks=1, n_langs=1, spk_emb_dim=64,
+                 lang_emb_dim=64):
         super().__init__(
             n_feats=in_channels,
             cfm_params=cfm_params,
             n_spks=n_spks,
+            n_langs=n_langs,
             spk_emb_dim=spk_emb_dim,
+            lang_emb_dim=lang_emb_dim,
         )
 
-        in_channels = in_channels + (spk_emb_dim if n_spks > 1 else 0)
+        in_channels = in_channels + (spk_emb_dim if n_spks > 1 else 0) + (lang_emb_dim if n_langs > 1 else 0)
         # Just change the architecture of the estimator here
         self.estimator = Decoder(in_channels=in_channels, out_channels=out_channel, **decoder_params)

--- a/matcha/models/components/text_encoder.py
+++ b/matcha/models/components/text_encoder.py
@@ -333,7 +333,9 @@ class TextEncoder(nn.Module):
         duration_predictor_params,
         n_vocab,
         n_spks=1,
+        n_langs=1,
         spk_emb_dim=128,
+        lang_emb_dim=128,
     ):
         super().__init__()
         self.encoder_type = encoder_type
@@ -342,15 +344,17 @@ class TextEncoder(nn.Module):
         self.n_channels = encoder_params.n_channels
         self.spk_emb_dim = spk_emb_dim
         self.n_spks = n_spks
+        self.lang_emb_dim = lang_emb_dim
+        self.n_langs = n_langs
 
         self.emb = torch.nn.Embedding(n_vocab, self.n_channels)
         torch.nn.init.normal_(self.emb.weight, 0.0, self.n_channels**-0.5)
 
         if encoder_params.prenet:
             self.prenet = ConvReluNorm(
-                self.n_channels,
-                self.n_channels,
-                self.n_channels,
+                self.n_channels + (lang_emb_dim if n_langs > 1 else 0),
+                self.n_channels + (lang_emb_dim if n_langs > 1 else 0),
+                self.n_channels + (lang_emb_dim if n_langs > 1 else 0),
                 kernel_size=5,
                 n_layers=3,
                 p_dropout=0.5,
@@ -359,7 +363,7 @@ class TextEncoder(nn.Module):
             self.prenet = lambda x, x_mask: x
 
         self.encoder = Encoder(
-            encoder_params.n_channels + (spk_emb_dim if n_spks > 1 else 0),
+            encoder_params.n_channels + (lang_emb_dim if n_langs > 1 else 0) + (spk_emb_dim if n_spks > 1 else 0),
             encoder_params.filter_channels,
             encoder_params.n_heads,
             encoder_params.n_layers,
@@ -367,15 +371,17 @@ class TextEncoder(nn.Module):
             encoder_params.p_dropout,
         )
 
-        self.proj_m = torch.nn.Conv1d(self.n_channels + (spk_emb_dim if n_spks > 1 else 0), self.n_feats, 1)
+        self.proj_m = torch.nn.Conv1d(
+            self.n_channels + (spk_emb_dim if n_spks > 1 else 0) + (lang_emb_dim if n_langs > 1 else 0),
+            self.n_feats, 1)
         self.proj_w = DurationPredictor(
-            self.n_channels + (spk_emb_dim if n_spks > 1 else 0),
+            self.n_channels + (spk_emb_dim if n_spks > 1 else 0) + (lang_emb_dim if n_langs > 1 else 0),
             duration_predictor_params.filter_channels_dp,
             duration_predictor_params.kernel_size,
             duration_predictor_params.p_dropout,
         )
 
-    def forward(self, x, x_lengths, spks=None):
+    def forward(self, x, x_lengths, spks=None, langs=None):
         """Run forward pass to the transformer based encoder and duration predictor
 
         Args:
@@ -398,6 +404,8 @@ class TextEncoder(nn.Module):
         x = torch.transpose(x, 1, -1)
         x_mask = torch.unsqueeze(sequence_mask(x_lengths, x.size(2)), 1).to(x.dtype)
 
+        if self.n_langs > 1:
+            x = torch.cat([x, langs.unsqueeze(-1).repeat(1, 1, x.shape[-1])], dim=1)
         x = self.prenet(x, x_mask)
         if self.n_spks > 1:
             x = torch.cat([x, spks.unsqueeze(-1).repeat(1, 1, x.shape[-1])], dim=1)

--- a/matcha/models/matcha_tts.py
+++ b/matcha/models/matcha_tts.py
@@ -3,6 +3,7 @@ import math
 import random
 
 import torch
+import torch.nn.functional as F
 
 import matcha.utils.monotonic_align as monotonic_align  # pylint: disable=consider-using-from-import
 from matcha import utils
@@ -36,6 +37,8 @@ class MatchaTTS(BaseLightningClass):  # 🍵
         scheduler=None,
         prior_loss=True,
         use_precomputed_durations=False,
+        n_langs=1,
+        lang_emb_dim=64,
     ):
         super().__init__()
 
@@ -48,9 +51,14 @@ class MatchaTTS(BaseLightningClass):  # 🍵
         self.out_size = out_size
         self.prior_loss = prior_loss
         self.use_precomputed_durations = use_precomputed_durations
+        self.n_langs = n_langs
+        self.lang_emb_dim = lang_emb_dim
 
         if n_spks > 1:
             self.spk_emb = torch.nn.Embedding(n_spks, spk_emb_dim)
+
+        if n_langs > 1:
+            self.lang_emb = torch.nn.Embedding(n_langs, lang_emb_dim)
 
         self.encoder = TextEncoder(
             encoder.encoder_type,
@@ -59,6 +67,8 @@ class MatchaTTS(BaseLightningClass):  # 🍵
             n_vocab,
             n_spks,
             spk_emb_dim,
+            n_langs,
+            lang_emb_dim,
         )
 
         self.decoder = CFM(
@@ -68,12 +78,14 @@ class MatchaTTS(BaseLightningClass):  # 🍵
             decoder_params=decoder,
             n_spks=n_spks,
             spk_emb_dim=spk_emb_dim,
+            n_langs=n_langs,
+            lang_emb_dim=lang_emb_dim,
         )
 
         self.update_data_statistics(data_statistics)
 
     @torch.inference_mode()
-    def synthesise(self, x, x_lengths, n_timesteps, temperature=1.0, spks=None, length_scale=1.0):
+    def synthesise(self, x, x_lengths, n_timesteps, temperature=1.0, spks=None, length_scale=1.0, langs=None):
         """
         Generates mel-spectrogram from text. Returns:
             1. encoder outputs
@@ -87,10 +99,12 @@ class MatchaTTS(BaseLightningClass):  # 🍵
                 shape: (batch_size,)
             n_timesteps (int): number of steps to use for reverse diffusion in decoder.
             temperature (float, optional): controls variance of terminal distribution.
-            spks (bool, optional): speaker ids.
+            spks (torch.Tensor, optional): speaker ids.
                 shape: (batch_size,)
             length_scale (float, optional): controls speech pace.
                 Increase value to slow down generated speech and vice versa.
+            langs (torch.Tensor, optional): language ids.
+                shape: (batch_size,)
 
         Returns:
             dict: {
@@ -114,9 +128,15 @@ class MatchaTTS(BaseLightningClass):  # 🍵
         if self.n_spks > 1:
             # Get speaker embedding
             spks = self.spk_emb(spks.long())
+            spks = F.normalize(spks, p=2, dim=-1)
+
+        if self.n_langs > 1:
+            # Get speaker embedding
+            langs = self.lang_emb(langs.long())
+            langs = F.normalize(langs, p=2, dim=-1)
 
         # Get encoder_outputs `mu_x` and log-scaled token durations `logw`
-        mu_x, logw, x_mask = self.encoder(x, x_lengths, spks)
+        mu_x, logw, x_mask = self.encoder(x, x_lengths, spks, langs)
 
         w = torch.exp(logw) * x_mask
         w_ceil = torch.ceil(w) * length_scale
@@ -135,7 +155,7 @@ class MatchaTTS(BaseLightningClass):  # 🍵
         encoder_outputs = mu_y[:, :, :y_max_length]
 
         # Generate sample tracing the probability flow
-        decoder_outputs = self.decoder(mu_y, y_mask, n_timesteps, temperature, spks)
+        decoder_outputs = self.decoder(mu_y, y_mask, n_timesteps, temperature, spks, langs)
         decoder_outputs = decoder_outputs[:, :, :y_max_length]
 
         t = (dt.datetime.now() - t).total_seconds()
@@ -150,7 +170,7 @@ class MatchaTTS(BaseLightningClass):  # 🍵
             "rtf": rtf,
         }
 
-    def forward(self, x, x_lengths, y, y_lengths, spks=None, out_size=None, cond=None, durations=None):
+    def forward(self, x, x_lengths, y, y_lengths, spks=None, out_size=None, cond=None, durations=None, langs=None):
         """
         Computes 3 losses:
             1. duration loss: loss between predicted token durations and those extracted by Monotonic Alignment Search (MAS).
@@ -170,13 +190,21 @@ class MatchaTTS(BaseLightningClass):  # 🍵
                 Should be divisible by 2^{num of UNet downsamplings}. Needed to increase batch size.
             spks (torch.Tensor, optional): speaker ids.
                 shape: (batch_size,)
+            langs (torch.Tensor, optional): language ids.
+                shape: (batch_size,)
         """
         if self.n_spks > 1:
             # Get speaker embedding
             spks = self.spk_emb(spks)
+            spks = F.normalize(spks, p=2, dim=-1)
+
+        if self.n_langs > 1:
+            # Get speaker embedding
+            langs = self.lang_emb(langs)
+            langs = F.normalize(langs, p=2, dim=-1)
 
         # Get encoder_outputs `mu_x` and log-scaled token durations `logw`
-        mu_x, logw, x_mask = self.encoder(x, x_lengths, spks)
+        mu_x, logw, x_mask = self.encoder(x, x_lengths, spks, langs)
         y_max_length = y.shape[-1]
 
         y_mask = sequence_mask(y_lengths, y_max_length).unsqueeze(1).to(x_mask)
@@ -234,7 +262,7 @@ class MatchaTTS(BaseLightningClass):  # 🍵
         mu_y = mu_y.transpose(1, 2)
 
         # Compute loss of the decoder
-        diff_loss, _ = self.decoder.compute_loss(x1=y, mask=y_mask, mu=mu_y, spks=spks, cond=cond)
+        diff_loss, _ = self.decoder.compute_loss(x1=y, mask=y_mask, mu=mu_y, spks=spks, cond=cond, langs=langs)
 
         if self.prior_loss:
             prior_loss = torch.sum(0.5 * ((y - mu_y) ** 2 + math.log(2 * math.pi)) * y_mask)


### PR DESCRIPTION
This pull request adds multi-language support to MatchaTTS by concatenating language embeddings to the encoder and decoder inputs.

**Speaker and Language Disentanglement:**  
When training with only a few monolingual speakers, speaker and language IDs are highly correlated. Therefore, it is likely (though not tested) that the model may have difficulty disentangling them. With multilingual speakers or a sufficiently large number of speakers, the model can better separate speaker and language information.

**How to Use:**  
Specify the number of languages using the `n_langs` key in the data config and annotate your data CSV as follows:

| filepath | spk | lang | text |
|----------|-----|------|------|

**Backward Compatibility:**  
If you set `n_langs: 1`, the system behaves as before this pull request, with one exception: both speaker and language embeddings are now L2-normalized (if used). In my experience, this helps maintain a balance between speaker and language information during training.

**Note:**  
This pull request does **not** include any text processing functions for additional languages. You will need to ensure that your text preprocessing pipeline supports the languages you intend to use.
