### PR TITLE
Restrict torch version range in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # --------- pytorch --------- #
-torch>=2.0.0
+torch>=2.0.0,<2.6.0
 torchvision>=0.15.0
 lightning>=2.0.0
 torchmetrics>=0.11.4


### PR DESCRIPTION
fix: pin torch < 2.6 to resolve unpickling error from default weights_only=True